### PR TITLE
revert incremental data to table, due to source overwrites the order_ids

### DIFF
--- a/lessons/models/staging/stg_ecommerce__orders.sql
+++ b/lessons/models/staging/stg_ecommerce__orders.sql
@@ -1,8 +1,6 @@
 {{
 	config(
-                materialized='incremental',
 		unique_key='order_id',
-		on_schema_change='sync_all_columns',
 		partition_by={
 			"field": "created_at",
 			"data_type": "timestamp",
@@ -27,9 +25,3 @@ SELECT
         num_of_item
 
 FROM source
-
-{% if is_incremental() %}
-
-WHERE created_at > (SELECT MAX(created_at) FROM {{ this }})
-
-{% endif %}


### PR DESCRIPTION
The source overwrites the ids and it creates inconsistancy when order table is incremental, but order_items is not